### PR TITLE
feat: People's Choice voting page

### DIFF
--- a/content/tutorials.json
+++ b/content/tutorials.json
@@ -48,5 +48,13 @@
     "amt": "5+hrs",
     "link":"https://movespiders.com/",
     "tags": ["Code Along", "Game"]
+  },
+  "On-Chain Voting with Signature Verification" : {
+    "category": "Intermediate",
+    "title": "On-Chain Voting with Signature Verification",
+    "description": "Build a complete on-chain voting system with Move smart contracts, Ed25519 eligibility proofs, and a Next.js frontend with wallet integration.",
+    "amt": "45m",
+    "link":"/tutorials/peoples-choice-voting",
+    "tags": ["Contract", "Full Stack", "Code Along"]
   }
 }

--- a/content/tutorials/peoples-choice-voting.md
+++ b/content/tutorials/peoples-choice-voting.md
@@ -40,7 +40,7 @@ The `vote` entry function enforces all invariants:
 4. Signature hasn't expired
 5. Ed25519 signature is valid against stored admin public key
 
-The message being signed is: `bcs::to_bytes(voter_address) ++ bcs::to_bytes(candidate_id) ++ bcs::to_bytes(expiry)`
+The message being signed is BCS-encoded: `bcs::to_bytes(voter_address) ++ bcs::to_bytes(candidate_id) ++ bcs::to_bytes(expiry)`
 
 This prevents replay attacks (address-bound), vote manipulation (candidate-bound), and stale eligibility (time-bound).
 
@@ -54,15 +54,12 @@ Three view functions expose read-only state:
 ### Deployment
 
 ```bash
-movement move publish --named-addresses peoples_choice=default --profile testnet
+movement move publish --named-addresses peoples_choice=default --profile default
 ```
 
 After deployment, initialize with:
 ```bash
-movement move run \
-  --function-id '<address>::peoples_choice::initialize' \
-  --args u64:5 'hex:<admin_public_key_hex>' \
-  --profile testnet
+movement move run --function-id 'default::peoples_choice::initialize' --args u64:5 'hex:<admin_public_key_hex>' --profile default --assume-yes
 ```
 
 ## 2. Ed25519 Keypair Generation
@@ -84,17 +81,47 @@ console.log("Public key (for contract init):", privateKey.publicKey().toString()
 
 The API route (`/api/check-eligibility`) does three things:
 
-1. Fetches user XP from Parthenon GraphQL API (server-side, using API key)
-2. If XP >= 100, signs an eligibility proof with Ed25519
+1. Fetches user XP from the Parthenon REST API (server-side, using API key)
+2. If XP >= 100, signs a BCS-encoded eligibility proof with Ed25519
 3. Returns the signature + expiry for the frontend to include in the vote transaction
 
+The message must be BCS-encoded to match what the contract reconstructs on-chain:
+
 ```typescript
-// Sign the eligibility proof
-const message = new TextEncoder().encode(`${address}:${candidateId}:${expiry}`);
-const signature = privateKey.sign(message);
+import { Ed25519PrivateKey, AccountAddress, Serializer } from "@aptos-labs/ts-sdk";
+
+async function signEligibility(address: string, candidateId: number, expiry: number) {
+  const privateKey = new Ed25519PrivateKey(process.env.ELIGIBILITY_SIGNER_KEY!);
+
+  // BCS-encode each field to match the contract's bcs::to_bytes() calls
+  const addrBytes = AccountAddress.from(address).bcsToBytes();
+
+  const candidateSer = new Serializer();
+  candidateSer.serializeU64(candidateId);
+  const candidateBytes = candidateSer.toUint8Array();
+
+  const expirySer = new Serializer();
+  expirySer.serializeU64(expiry);
+  const expiryBytes = expirySer.toUint8Array();
+
+  // Concatenate: bcs(address) ++ bcs(candidate_id) ++ bcs(expiry)
+  const message = new Uint8Array([...addrBytes, ...candidateBytes, ...expiryBytes]);
+
+  const signature = privateKey.sign(message);
+  return signature.toString();
+}
 ```
 
-The contract independently reconstructs this message and verifies the signature, ensuring only the server (with the private key) can authorize votes.
+The Parthenon API is called as a REST endpoint:
+
+```typescript
+const res = await fetch(
+  `https://parthenon-api.movementlabs.xyz/api/users/xp-by-address?address=${address}`,
+  { headers: { "X-API-KEY": process.env.PARTHENON_API_KEY! } }
+);
+const data = await res.json();
+const xp = data?.data?.xp ?? 0;
+```
 
 ## 4. Wallet Integration (Next.js)
 
@@ -104,10 +131,17 @@ Wrap only the voting page in `AptosWalletAdapterProvider` to avoid loading walle
 
 ```tsx
 // layout.tsx (scoped to /events/peopleschoice)
+import { AptosConfig, Network } from "@aptos-labs/ts-sdk";
+
+const aptosConfig = new AptosConfig({
+  network: Network.MAINNET,
+  fullnode: "https://mainnet.movementnetwork.xyz/v1",
+});
+
 <AptosWalletAdapterProvider
   autoConnect={true}
-  dappConfig={{ network: Network.CUSTOM }}
-  optInWallets={["Nightly", "Razor Wallet"]}
+  dappConfig={aptosConfig}
+  onError={(error) => console.error("Wallet error:", error)}
 >
   {children}
 </AptosWalletAdapterProvider>
@@ -115,16 +149,34 @@ Wrap only the voting page in `AptosWalletAdapterProvider` to avoid loading walle
 
 ### Vote Submission
 
+The signature from the API is a hex string that must be converted to `Uint8Array` before passing as a `vector<u8>` argument to the contract:
+
 ```tsx
 const { signAndSubmitTransaction } = useWallet();
 
-await signAndSubmitTransaction({
+// Convert hex signature to bytes
+const sigHex = signature.replace(/^0x/, "");
+const sigBytes = new Uint8Array(
+  sigHex.match(/.{1,2}/g)!.map((byte) => parseInt(byte, 16))
+);
+
+const response = await signAndSubmitTransaction({
+  sender: account.address,
   data: {
     function: `${MODULE_ADDRESS}::peoples_choice::vote`,
-    typeArguments: [],
-    functionArguments: [candidateId, signature, expiry],
+    functionArguments: [candidateId, sigBytes, expiry],
   },
 });
+
+// Wait for on-chain confirmation
+const txResult = await aptos.waitForTransaction({
+  transactionHash: response.hash,
+  options: { checkSuccess: true },
+});
+
+if (!txResult.success) {
+  // Handle failure
+}
 ```
 
 ## 5. Frontend State Machine
@@ -136,12 +188,15 @@ DISCONNECTED → [connect wallet] → CONNECTED → CHECKING_ELIGIBILITY
   → ELIGIBLE → [click vote] → VOTING → VOTED
   → INELIGIBLE (show XP requirement)
   → ALREADY_VOTED (show which project)
+  → ERROR (show message + try again)
 ```
 
 Vote counts are polled every 15 seconds via view function calls and visible to all users regardless of wallet connection.
 
 ## Security Considerations
 
+- **BCS encoding:** Both server and contract must construct identical messages using BCS serialization — text encoding won't match
+- **Signature format:** The API returns a hex string, but the contract expects raw bytes (`vector<u8>`). The frontend must convert hex to `Uint8Array` before submitting
 - **Replay prevention:** Signature binds to specific address + candidate + expiry window
 - **Server authority:** Only the server with the private key can produce valid eligibility proofs
 - **On-chain enforcement:** Contract verifies everything; the server cannot force a double-vote

--- a/content/tutorials/peoples-choice-voting.md
+++ b/content/tutorials/peoples-choice-voting.md
@@ -1,0 +1,157 @@
+# Building On-Chain Voting with Signature Verification on Movement
+
+This tutorial walks through building a complete on-chain voting system using Move smart contracts, Ed25519 signature verification for off-chain eligibility, and a Next.js frontend with wallet integration.
+
+## Architecture Overview
+
+```
+User connects wallet → Frontend checks eligibility via API →
+API verifies XP on Parthenon → Signs eligibility proof (Ed25519) →
+User submits vote tx with signature → Contract verifies signature on-chain →
+Vote recorded, 1-vote-per-address enforced
+```
+
+**Key design decision:** Eligibility is checked off-chain (server has API key) but **enforced on-chain** via cryptographic signature verification. The server signs a message proving the user is eligible, and the contract verifies that signature before accepting the vote.
+
+## 1. Smart Contract Design (Move)
+
+### Resources
+
+The contract stores all voting state in a single resource:
+
+```move
+struct VotingState has key {
+    votes: vector<u64>,              // index = candidate, value = count
+    voters: SimpleMap<address, u64>, // voter -> candidate they voted for
+    num_candidates: u64,
+    is_paused: bool,
+    admin: address,
+    admin_public_key: ed25519::UnvalidatedPublicKey,
+}
+```
+
+### Vote Function with Signature Verification
+
+The `vote` entry function enforces all invariants:
+
+1. Voting is not paused
+2. Candidate ID is valid
+3. Voter hasn't already voted
+4. Signature hasn't expired
+5. Ed25519 signature is valid against stored admin public key
+
+The message being signed is: `bcs::to_bytes(voter_address) ++ bcs::to_bytes(candidate_id) ++ bcs::to_bytes(expiry)`
+
+This prevents replay attacks (address-bound), vote manipulation (candidate-bound), and stale eligibility (time-bound).
+
+### View Functions
+
+Three view functions expose read-only state:
+- `get_votes()` - returns vote counts for all candidates
+- `has_voted(addr)` - checks if an address has voted
+- `get_voter_choice(addr)` - returns which candidate they voted for
+
+### Deployment
+
+```bash
+movement move publish --named-addresses peoples_choice=default --profile testnet
+```
+
+After deployment, initialize with:
+```bash
+movement move run \
+  --function-id '<address>::peoples_choice::initialize' \
+  --args u64:5 'hex:<admin_public_key_hex>' \
+  --profile testnet
+```
+
+## 2. Ed25519 Keypair Generation
+
+Generate the keypair that links your API server to the contract:
+
+```typescript
+import { Ed25519PrivateKey } from "@aptos-labs/ts-sdk";
+
+const privateKey = Ed25519PrivateKey.generate();
+console.log("Private key (for .env):", privateKey.toString());
+console.log("Public key (for contract init):", privateKey.publicKey().toString());
+```
+
+- **Private key** goes in `.env.local` as `ELIGIBILITY_SIGNER_KEY`
+- **Public key** goes to the contract's `initialize()` call
+
+## 3. API Route - Eligibility Check + Signing
+
+The API route (`/api/check-eligibility`) does three things:
+
+1. Fetches user XP from Parthenon GraphQL API (server-side, using API key)
+2. If XP >= 100, signs an eligibility proof with Ed25519
+3. Returns the signature + expiry for the frontend to include in the vote transaction
+
+```typescript
+// Sign the eligibility proof
+const message = new TextEncoder().encode(`${address}:${candidateId}:${expiry}`);
+const signature = privateKey.sign(message);
+```
+
+The contract independently reconstructs this message and verifies the signature, ensuring only the server (with the private key) can authorize votes.
+
+## 4. Wallet Integration (Next.js)
+
+### Scoped Provider
+
+Wrap only the voting page in `AptosWalletAdapterProvider` to avoid loading wallet code across the entire site:
+
+```tsx
+// layout.tsx (scoped to /events/peopleschoice)
+<AptosWalletAdapterProvider
+  autoConnect={true}
+  dappConfig={{ network: Network.CUSTOM }}
+  optInWallets={["Nightly", "Razor Wallet"]}
+>
+  {children}
+</AptosWalletAdapterProvider>
+```
+
+### Vote Submission
+
+```tsx
+const { signAndSubmitTransaction } = useWallet();
+
+await signAndSubmitTransaction({
+  data: {
+    function: `${MODULE_ADDRESS}::peoples_choice::vote`,
+    typeArguments: [],
+    functionArguments: [candidateId, signature, expiry],
+  },
+});
+```
+
+## 5. Frontend State Machine
+
+The voting page follows a clear state machine:
+
+```
+DISCONNECTED → [connect wallet] → CONNECTED → CHECKING_ELIGIBILITY
+  → ELIGIBLE → [click vote] → VOTING → VOTED
+  → INELIGIBLE (show XP requirement)
+  → ALREADY_VOTED (show which project)
+```
+
+Vote counts are polled every 15 seconds via view function calls and visible to all users regardless of wallet connection.
+
+## Security Considerations
+
+- **Replay prevention:** Signature binds to specific address + candidate + expiry window
+- **Server authority:** Only the server with the private key can produce valid eligibility proofs
+- **On-chain enforcement:** Contract verifies everything; the server cannot force a double-vote
+- **Admin controls:** Pause/unpause for emergency situations
+- **No API key exposure:** Parthenon API key stays server-side
+
+## Environment Variables
+
+```
+PARTHENON_API_KEY=<your-parthenon-key>
+ELIGIBILITY_SIGNER_KEY=<ed25519-private-key-hex>
+NEXT_PUBLIC_CONTRACT_ADDRESS=<deployed-contract-address>
+```

--- a/contracts/peoples_choice/Move.toml
+++ b/contracts/peoples_choice/Move.toml
@@ -1,0 +1,16 @@
+[package]
+name = "peoples_choice"
+version = "1.0.0"
+authors = []
+
+[addresses]
+peoples_choice = "0x9e125ef34b46202e928ce15d2d0681cfb974394e2085569fd8839240a4c6dc0e"
+
+[dev-addresses]
+
+[dependencies.AptosFramework]
+git = "https://github.com/movementlabsxyz/aptos-core.git"
+rev = "m1"
+subdir = "aptos-move/framework/aptos-framework"
+
+[dev-dependencies]

--- a/contracts/peoples_choice/sources/peoples_choice.move
+++ b/contracts/peoples_choice/sources/peoples_choice.move
@@ -1,0 +1,135 @@
+module peoples_choice::peoples_choice {
+    use std::vector;
+    use std::signer;
+    use aptos_std::simple_map::{Self, SimpleMap};
+    use aptos_std::ed25519;
+    use aptos_framework::timestamp;
+    use std::bcs;
+
+    const E_NOT_ADMIN: u64 = 1;
+    const E_ALREADY_INITIALIZED: u64 = 2;
+    const E_NOT_INITIALIZED: u64 = 3;
+    const E_INVALID_CANDIDATE: u64 = 4;
+    const E_ALREADY_VOTED: u64 = 5;
+    const E_VOTING_PAUSED: u64 = 6;
+    const E_SIGNATURE_EXPIRED: u64 = 7;
+    const E_INVALID_SIGNATURE: u64 = 8;
+
+    struct VotingState has key {
+        votes: vector<u64>,
+        voters: SimpleMap<address, u64>,
+        num_candidates: u64,
+        is_paused: bool,
+        admin: address,
+        admin_public_key: ed25519::UnvalidatedPublicKey,
+    }
+
+    public entry fun initialize(
+        admin: &signer,
+        num_candidates: u64,
+        admin_public_key: vector<u8>,
+    ) {
+        let admin_addr = signer::address_of(admin);
+        assert!(!exists<VotingState>(admin_addr), E_ALREADY_INITIALIZED);
+
+        let votes = vector::empty<u64>();
+        let i = 0;
+        while (i < num_candidates) {
+            vector::push_back(&mut votes, 0);
+            i = i + 1;
+        };
+
+        move_to(admin, VotingState {
+            votes,
+            voters: simple_map::create<address, u64>(),
+            num_candidates,
+            is_paused: false,
+            admin: admin_addr,
+            admin_public_key: ed25519::new_unvalidated_public_key_from_bytes(admin_public_key),
+        });
+    }
+
+    public entry fun vote(
+        voter: &signer,
+        candidate_id: u64,
+        signature_bytes: vector<u8>,
+        expiry: u64,
+    ) acquires VotingState {
+        let contract_addr = @peoples_choice;
+        assert!(exists<VotingState>(contract_addr), E_NOT_INITIALIZED);
+
+        let state = borrow_global_mut<VotingState>(contract_addr);
+
+        assert!(!state.is_paused, E_VOTING_PAUSED);
+        assert!(candidate_id < state.num_candidates, E_INVALID_CANDIDATE);
+
+        let voter_addr = signer::address_of(voter);
+        assert!(
+            !simple_map::contains_key(&state.voters, &voter_addr),
+            E_ALREADY_VOTED,
+        );
+
+        assert!(timestamp::now_seconds() < expiry, E_SIGNATURE_EXPIRED);
+
+        let message = bcs::to_bytes(&voter_addr);
+        let candidate_bytes = bcs::to_bytes(&candidate_id);
+        let expiry_bytes = bcs::to_bytes(&expiry);
+        vector::append(&mut message, candidate_bytes);
+        vector::append(&mut message, expiry_bytes);
+
+        let sig = ed25519::new_signature_from_bytes(signature_bytes);
+        assert!(
+            ed25519::signature_verify_strict(
+                &sig,
+                &state.admin_public_key,
+                message,
+            ),
+            E_INVALID_SIGNATURE,
+        );
+
+        let current_count = *vector::borrow(&state.votes, candidate_id);
+        *vector::borrow_mut(&mut state.votes, candidate_id) = current_count + 1;
+        simple_map::add(&mut state.voters, voter_addr, candidate_id);
+    }
+
+    public entry fun pause(admin: &signer) acquires VotingState {
+        let contract_addr = @peoples_choice;
+        let state = borrow_global_mut<VotingState>(contract_addr);
+        assert!(signer::address_of(admin) == state.admin, E_NOT_ADMIN);
+        state.is_paused = true;
+    }
+
+    public entry fun unpause(admin: &signer) acquires VotingState {
+        let contract_addr = @peoples_choice;
+        let state = borrow_global_mut<VotingState>(contract_addr);
+        assert!(signer::address_of(admin) == state.admin, E_NOT_ADMIN);
+        state.is_paused = false;
+    }
+
+    #[view]
+    public fun get_votes(): vector<u64> acquires VotingState {
+        let contract_addr = @peoples_choice;
+        if (!exists<VotingState>(contract_addr)) {
+            return vector::empty<u64>()
+        };
+        let state = borrow_global<VotingState>(contract_addr);
+        state.votes
+    }
+
+    #[view]
+    public fun has_voted(addr: address): bool acquires VotingState {
+        let contract_addr = @peoples_choice;
+        if (!exists<VotingState>(contract_addr)) {
+            return false
+        };
+        let state = borrow_global<VotingState>(contract_addr);
+        simple_map::contains_key(&state.voters, &addr)
+    }
+
+    #[view]
+    public fun get_voter_choice(addr: address): u64 acquires VotingState {
+        let contract_addr = @peoples_choice;
+        let state = borrow_global<VotingState>(contract_addr);
+        *simple_map::borrow(&state.voters, &addr)
+    }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@aptos-labs/ts-sdk": "^5.2.1",
+    "@aptos-labs/wallet-adapter-react": "^8.3.0",
+    "@aptos-labs/wallet-standard": "^0.5.2",
     "@contentful/rich-text-react-renderer": "^15.22.11",
     "@contentful/rich-text-types": "^16.8.5",
     "@lottiefiles/dotlottie-react": "^0.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@aptos-labs/ts-sdk':
+        specifier: ^5.2.1
+        version: 5.2.1(got@11.8.6)
+      '@aptos-labs/wallet-adapter-react':
+        specifier: ^8.3.0
+        version: 8.3.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@types/react@18.3.27)(@wallet-standard/core@1.0.3)(react@18.3.1)
+      '@aptos-labs/wallet-standard':
+        specifier: ^0.5.2
+        version: 0.5.2(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)
       '@contentful/rich-text-react-renderer':
         specifier: ^15.22.11
         version: 15.22.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -19,7 +28,7 @@ importers:
         version: 0.9.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@movementlabsxyz/movement-design-system':
         specifier: github:MoveIndustries/movement-design-system
-        version: '@moveindustries/movement-design-system@https://codeload.github.com/MoveIndustries/movement-design-system/tar.gz/181b2a0eb9ddeb7e03b75450f4eb6eeaa32827de(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@aptos-labs/wallet-adapter-core@7.8.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6)))(@aptos-labs/wallet-adapter-react@7.2.2(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@types/react@18.3.27)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))(react@18.3.1))(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.3.5(graphql@16.12.0)))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))(axios@1.13.2)(got@11.8.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@4.1.17)(vite@7.2.4(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.2)(yaml@2.5.1))'
+        version: '@moveindustries/movement-design-system@https://codeload.github.com/MoveIndustries/movement-design-system/tar.gz/181b2a0eb9ddeb7e03b75450f4eb6eeaa32827de(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@aptos-labs/wallet-adapter-core@8.4.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3))(@aptos-labs/wallet-adapter-react@8.3.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@types/react@18.3.27)(@wallet-standard/core@1.0.3)(react@18.3.1))(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.3.5(graphql@16.12.0)))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))(axios@1.13.2)(got@11.8.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@4.1.17)(vite@7.2.4(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.2)(yaml@2.5.1))'
       '@tailwindcss/postcss':
         specifier: ^4.1.17
         version: 4.1.17
@@ -123,11 +132,21 @@ packages:
     peerDependencies:
       '@aptos-labs/ts-sdk': ^1.33.1 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
 
+  '@aptos-connect/wallet-adapter-plugin@3.0.2':
+    resolution: {integrity: sha512-6CvTUDktqGJFjp4M/FO5MHPHq3GtsL7JIpw5xCJjs19qLfhtRIKE+okjRhv7CrFyqcJroOIhCuZTqzPWEmTl+A==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': ^1.33.1 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
+
   '@aptos-connect/wallet-api@0.5.0':
     resolution: {integrity: sha512-fXwgCj0ZZoNGfXuwjsWtb/L9n6nkspxPBPrvdmNxjKi0nbxUUGShYHIAujJwkmOs5ODjjI6fk26zRMkXFoVxlA==}
     peerDependencies:
       '@aptos-labs/ts-sdk': ^1.33.1 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
       aptos: ^1.20.0
+
+  '@aptos-connect/wallet-api@0.6.0':
+    resolution: {integrity: sha512-y+2liopFkD1TfxqhBiYYFVbG5O4AA4AeUsMajpelPh3p6a0JXgVHAHOcuiVFSUi23hIqVbfjP1gIgK7afsNvlw==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': ^1.33.1 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
 
   '@aptos-connect/web-transport@0.4.1':
     resolution: {integrity: sha512-I/GeyDfpp6nlCWD7N6dPgFk9AYVV21L9Dm+yZL8YqfAjxV9lOAj9kDHY+CIbKvT0tpJbHZarbKCMK3Z8RhG2EQ==}
@@ -136,6 +155,13 @@ packages:
       '@aptos-labs/wallet-standard': ^0.5.0
       '@telegram-apps/bridge': ^1.0.0
       aptos: ^1.20.0
+
+  '@aptos-connect/web-transport@0.6.1':
+    resolution: {integrity: sha512-wyzOsYnYltTduI1ZbHwOz5PDxQ0K1LuABOtllV9z+rhUdDABKGSOdCO/0L0ybI9LYE4epvTYxcn72B7rjIQkMg==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': ^1.33.1 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
+      '@aptos-labs/wallet-standard': ^0.5.0
+      '@telegram-apps/bridge': ^1.0.0
 
   '@aptos-labs/aptos-cli@1.0.2':
     resolution: {integrity: sha512-PYPsd0Kk3ynkxNfe3S4fanI3DiUICCoh4ibQderbvjPFL5A0oK6F4lPEO2t0MDsQySTk2t4vh99Xjy6Bd9y+aQ==}
@@ -154,6 +180,12 @@ packages:
     peerDependencies:
       got: ^11.8.6
 
+  '@aptos-labs/aptos-client@2.1.0':
+    resolution: {integrity: sha512-ttdY0qclRvbYAAwzijkFeipuqTfLFJnoXlNIm58tIw3DKhIlfYdR6iLqTeCpI23oOPghnO99FZecej/0MTrtuA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      got: ^11.8.6
+
   '@aptos-labs/aptos-dynamic-transaction-composer@0.1.4':
     resolution: {integrity: sha512-ebsNJIntwcdaf5UTr9zivI/iS+b51BpDlQznKfsSPbOoEybHMlf0GjylKWpD0lktZydlLRoZxBlxCzAJAIr0VA==}
 
@@ -164,19 +196,23 @@ packages:
     resolution: {integrity: sha512-VFEWZsqb8Mto8XbLK8lDRdUvyHjp+geiwFxRzRcQK6HftMGB4bYuEsOI2Vy6u/TqkUft8DvmpV5yX027R5/SMQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aptos-labs/ts-sdk@5.2.1':
+    resolution: {integrity: sha512-kazYjqfsPCBx2UJI+nYUOb6Ov7q7brSgYEfxp2sP27IeJWdDNa50lfs0WIpDJ92kQxdtlm9q3ZWw7Toh9f1gxQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aptos-labs/wallet-adapter-core@4.25.0':
     resolution: {integrity: sha512-TMiHvteU/DvL9p8npna32kRjCsJdiQgP83QhFLoZKV1rGhvB9NwCs1BnPzoCSTCkgfGkWqZGjVmhynX2p+HZEA==}
     peerDependencies:
       '@aptos-labs/ts-sdk': ^1.33.1
       aptos: ^1.21.0
 
-  '@aptos-labs/wallet-adapter-core@7.8.0':
-    resolution: {integrity: sha512-ae68POGrunHg9c8S8wlbfWk0o5cYnH13tF2Ty6OE0ElUS2iG9lzrXo3idCGiiXw0H9QV3BFdQtPsN4tTsKnmyQ==}
+  '@aptos-labs/wallet-adapter-core@8.4.0':
+    resolution: {integrity: sha512-STAqTEwhJnnq284/H9JPz8z5N8KrIjF6c8mAfTMHboHhRWYDPA6LbvmLrR8wX72jiSUdQfM08wsNEkgTskvRWw==}
     peerDependencies:
       '@aptos-labs/ts-sdk': ^5.1.1
 
-  '@aptos-labs/wallet-adapter-react@7.2.2':
-    resolution: {integrity: sha512-NqS47s2PZj3o/xvFGkcn+1/ug0uMiWO4MFttJHG1017n3VsV0pva8V7/YePBOrb7GjbEH0tAoAz2JhGrBorXFA==}
+  '@aptos-labs/wallet-adapter-react@8.3.0':
+    resolution: {integrity: sha512-8123363MsZUEXweBy+hKFNyXKOmjjIA0RAO+l/lUWhZalmVQL/lnxQnMzrJ8wavn21IbLqCnfFZ5ClkfXUnCsw==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
 
@@ -456,8 +492,16 @@ packages:
   '@identity-connect/api@0.7.0':
     resolution: {integrity: sha512-mn/LZGeb3xgBD644p67tYOjvYSSdZpwxiO4/ZjwjsJZ8eYvGha5FiZg+pqVH73lg1S36qikwbkA3HUQOAE5GKA==}
 
+  '@identity-connect/api@0.8.0':
+    resolution: {integrity: sha512-BZQxaJnm3hkpwMGUio35ik28I8JomWIzPZn/lBl3ErrvUo02+2ixaYtVwD4MvC9RMY54AZvQaHfyFjuCaaM9+g==}
+
   '@identity-connect/crypto@0.2.11':
     resolution: {integrity: sha512-vpJhHuHsttjYhCMhYNVBtDOhgM0nIH9tGg6S5g3kFCOll3OXqT8I5hsNFL4RtIjMBoS5wjn5S8GK2bARAUjaGA==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': ^1.33.1 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
+
+  '@identity-connect/crypto@0.3.0':
+    resolution: {integrity: sha512-PexQZ+AyC6wdokNnsdm9MJPlyWnA0YHEV14mzx144r43+4FsmHTpRyeB6i7s8Fvwp6f2yyOLU4VojIQ7ajWcRA==}
     peerDependencies:
       '@aptos-labs/ts-sdk': ^1.33.1 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
 
@@ -467,11 +511,22 @@ packages:
       '@aptos-labs/ts-sdk': ^1.33.1 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
       '@aptos-labs/wallet-standard': ^0.5.0
 
+  '@identity-connect/dapp-sdk@0.16.1':
+    resolution: {integrity: sha512-Zy1KMPSxLc5HRCSxORjYtTGG3S85RMdQ9oKm9m9v7ia6T0MS9V0JSWXF/mv2wTaW66EL+zMPzpWL8eCWyZC1wg==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': ^1.33.1 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
+      '@aptos-labs/wallet-standard': ^0.5.0
+
   '@identity-connect/wallet-api@0.1.4':
     resolution: {integrity: sha512-nXEfUYl1t9mgQu1RRmqH7lcWnsxet5IWtnsno5Vx5jw8PibVZDD5kgy5sZ3k/Brvw8DlhKPIjDwcYNAgcNHhvg==}
     peerDependencies:
       '@aptos-labs/ts-sdk': ^1.33.1 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
       aptos: ^1.20.0
+
+  '@identity-connect/wallet-api@0.2.0':
+    resolution: {integrity: sha512-23Toe3bxeUN/DLsbBVYbt7gmG+msxxzAh19nXYjj32ybz0mKLLsdQWTf/nzqesmMD7r2u8QCF1ZYclm8Oie2Kg==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': ^1.33.1 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -4204,35 +4259,65 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@aptos-connect/wallet-adapter-plugin@2.7.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))':
+  '@aptos-connect/wallet-adapter-plugin@2.7.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-api': 0.5.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))
-      '@aptos-labs/ts-sdk': 1.39.0(axios@1.13.2)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@wallet-standard/core@1.0.3)
-      '@identity-connect/crypto': 0.2.11(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))
-      '@identity-connect/dapp-sdk': 0.14.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))
+      '@aptos-connect/wallet-api': 0.5.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))
+      '@aptos-labs/ts-sdk': 5.2.1(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)
+      '@identity-connect/crypto': 0.2.11(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))
+      '@identity-connect/dapp-sdk': 0.14.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))
     transitivePeerDependencies:
       - '@telegram-apps/bridge'
       - '@wallet-standard/core'
       - aptos
       - debug
 
-  '@aptos-connect/wallet-api@0.5.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))':
+  '@aptos-connect/wallet-adapter-plugin@3.0.2(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.39.0(axios@1.13.2)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@wallet-standard/core@1.0.3)
+      '@aptos-connect/wallet-api': 0.6.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)
+      '@aptos-labs/ts-sdk': 5.2.1(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)
+      '@identity-connect/crypto': 0.3.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)
+      '@identity-connect/dapp-sdk': 0.16.1(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)
+    transitivePeerDependencies:
+      - '@telegram-apps/bridge'
+      - '@wallet-standard/core'
+      - debug
+
+  '@aptos-connect/wallet-api@0.5.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))':
+    dependencies:
+      '@aptos-labs/ts-sdk': 5.2.1(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)
       '@identity-connect/api': 0.7.0
       aptos: 1.22.1(got@11.8.6)
     transitivePeerDependencies:
       - '@wallet-standard/core'
 
-  '@aptos-connect/web-transport@0.4.1(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))':
+  '@aptos-connect/wallet-api@0.6.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)':
     dependencies:
-      '@aptos-connect/wallet-api': 0.5.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))
-      '@aptos-labs/ts-sdk': 1.39.0(axios@1.13.2)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@wallet-standard/core@1.0.3)
+      '@aptos-labs/ts-sdk': 5.2.1(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)
+      '@identity-connect/api': 0.8.0
+    transitivePeerDependencies:
+      - '@wallet-standard/core'
+
+  '@aptos-connect/web-transport@0.4.1(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))':
+    dependencies:
+      '@aptos-connect/wallet-api': 0.5.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))
+      '@aptos-labs/ts-sdk': 5.2.1(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)
       '@telegram-apps/bridge': 1.9.2
       aptos: 1.22.1(got@11.8.6)
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@wallet-standard/core'
+
+  '@aptos-connect/web-transport@0.6.1(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)':
+    dependencies:
+      '@aptos-connect/wallet-api': 0.6.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)
+      '@aptos-labs/ts-sdk': 5.2.1(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)
+      '@telegram-apps/bridge': 1.9.2
       uuid: 9.0.1
     transitivePeerDependencies:
       - '@wallet-standard/core'
@@ -4247,6 +4332,10 @@ snapshots:
       got: 11.8.6
 
   '@aptos-labs/aptos-client@2.0.0(got@11.8.6)':
+    dependencies:
+      got: 11.8.6
+
+  '@aptos-labs/aptos-client@2.1.0(got@11.8.6)':
     dependencies:
       got: 11.8.6
 
@@ -4274,13 +4363,28 @@ snapshots:
       - axios
       - got
 
-  '@aptos-labs/wallet-adapter-core@4.25.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.3.5(graphql@16.12.0)))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))(axios@1.13.2)(got@11.8.6)':
+  '@aptos-labs/ts-sdk@5.2.1(got@11.8.6)':
     dependencies:
-      '@aptos-connect/wallet-adapter-plugin': 2.7.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))
-      '@aptos-labs/ts-sdk': 1.39.0(axios@1.13.2)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@wallet-standard/core@1.0.3)
-      '@atomrigslab/aptos-wallet-adapter': 0.1.21(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(axios@1.13.2)(got@11.8.6)
-      '@mizuwallet-sdk/aptos-wallet-adapter': 0.3.2(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.3.5(graphql@16.12.0)))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.0.3)(axios@1.13.2)(got@11.8.6)
+      '@aptos-labs/aptos-cli': 1.0.2
+      '@aptos-labs/aptos-client': 2.1.0(got@11.8.6)
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      eventemitter3: 5.0.1
+      js-base64: 3.7.8
+      jwt-decode: 4.0.0
+      poseidon-lite: 0.2.1
+    transitivePeerDependencies:
+      - got
+
+  '@aptos-labs/wallet-adapter-core@4.25.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.3.5(graphql@16.12.0)))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))(axios@1.13.2)(got@11.8.6)':
+    dependencies:
+      '@aptos-connect/wallet-adapter-plugin': 2.7.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))
+      '@aptos-labs/ts-sdk': 5.2.1(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)
+      '@atomrigslab/aptos-wallet-adapter': 0.1.21(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(axios@1.13.2)(got@11.8.6)
+      '@mizuwallet-sdk/aptos-wallet-adapter': 0.3.2(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.3.5(graphql@16.12.0)))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.0.3)(axios@1.13.2)(got@11.8.6)
       aptos: 1.22.1(got@11.8.6)
       buffer: 6.0.3
       eventemitter3: 4.0.7
@@ -4294,23 +4398,22 @@ snapshots:
       - debug
       - got
 
-  '@aptos-labs/wallet-adapter-core@7.8.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))':
+  '@aptos-labs/wallet-adapter-core@8.4.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)':
     dependencies:
-      '@aptos-connect/wallet-adapter-plugin': 2.7.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))
-      '@aptos-labs/ts-sdk': 1.39.0(axios@1.13.2)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@wallet-standard/core@1.0.3)
+      '@aptos-connect/wallet-adapter-plugin': 3.0.2(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)
+      '@aptos-labs/ts-sdk': 5.2.1(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)
       buffer: 6.0.3
       eventemitter3: 4.0.7
       tweetnacl: 1.0.3
     transitivePeerDependencies:
       - '@telegram-apps/bridge'
       - '@wallet-standard/core'
-      - aptos
       - debug
 
-  '@aptos-labs/wallet-adapter-react@7.2.2(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@types/react@18.3.27)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))(react@18.3.1)':
+  '@aptos-labs/wallet-adapter-react@8.3.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@types/react@18.3.27)(@wallet-standard/core@1.0.3)(react@18.3.1)':
     dependencies:
-      '@aptos-labs/wallet-adapter-core': 7.8.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))
+      '@aptos-labs/wallet-adapter-core': 8.4.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)
       '@radix-ui/react-slot': 1.2.4(@types/react@18.3.27)(react@18.3.1)
       react: 18.3.1
     transitivePeerDependencies:
@@ -4318,9 +4421,7 @@ snapshots:
       - '@telegram-apps/bridge'
       - '@types/react'
       - '@wallet-standard/core'
-      - aptos
       - debug
-    optional: true
 
   '@aptos-labs/wallet-standard@0.0.11(axios@1.13.2)(got@11.8.6)':
     dependencies:
@@ -4335,19 +4436,19 @@ snapshots:
       '@aptos-labs/ts-sdk': 1.39.0(axios@1.13.2)(got@11.8.6)
       '@wallet-standard/core': 1.0.3
 
-  '@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@wallet-standard/core@1.0.3)':
+  '@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.39.0(axios@1.13.2)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 5.2.1(got@11.8.6)
       '@wallet-standard/core': 1.0.3
 
-  '@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@wallet-standard/core@1.0.3)':
+  '@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.39.0(axios@1.13.2)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 5.2.1(got@11.8.6)
       '@wallet-standard/core': 1.0.3
 
-  '@atomrigslab/aptos-wallet-adapter@0.1.21(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(axios@1.13.2)(got@11.8.6)':
+  '@atomrigslab/aptos-wallet-adapter@0.1.21(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(axios@1.13.2)(got@11.8.6)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.39.0(axios@1.13.2)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 5.2.1(got@11.8.6)
       '@aptos-labs/wallet-standard': 0.0.11(axios@1.13.2)(got@11.8.6)
       '@atomrigslab/dekey-web-wallet-provider': 1.2.1
     transitivePeerDependencies:
@@ -4542,10 +4643,12 @@ snapshots:
 
   '@identity-connect/api@0.7.0': {}
 
-  '@identity-connect/crypto@0.2.11(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))':
+  '@identity-connect/api@0.8.0': {}
+
+  '@identity-connect/crypto@0.2.11(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-api': 0.5.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))
-      '@aptos-labs/ts-sdk': 1.39.0(axios@1.13.2)(got@11.8.6)
+      '@aptos-connect/wallet-api': 0.5.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))
+      '@aptos-labs/ts-sdk': 5.2.1(got@11.8.6)
       '@noble/hashes': 1.8.0
       ed2curve: 0.3.0
       tweetnacl: 1.0.3
@@ -4553,15 +4656,25 @@ snapshots:
       - '@wallet-standard/core'
       - aptos
 
-  '@identity-connect/dapp-sdk@0.14.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))':
+  '@identity-connect/crypto@0.3.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)':
     dependencies:
-      '@aptos-connect/wallet-api': 0.5.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))
-      '@aptos-connect/web-transport': 0.4.1(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))
-      '@aptos-labs/ts-sdk': 1.39.0(axios@1.13.2)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@wallet-standard/core@1.0.3)
+      '@aptos-connect/wallet-api': 0.6.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)
+      '@aptos-labs/ts-sdk': 5.2.1(got@11.8.6)
+      '@noble/hashes': 1.8.0
+      ed2curve: 0.3.0
+      tweetnacl: 1.0.3
+    transitivePeerDependencies:
+      - '@wallet-standard/core'
+
+  '@identity-connect/dapp-sdk@0.14.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))':
+    dependencies:
+      '@aptos-connect/wallet-api': 0.5.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))
+      '@aptos-connect/web-transport': 0.4.1(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))
+      '@aptos-labs/ts-sdk': 5.2.1(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)
       '@identity-connect/api': 0.7.0
-      '@identity-connect/crypto': 0.2.11(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))
-      '@identity-connect/wallet-api': 0.1.4(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(aptos@1.22.1(got@11.8.6))
+      '@identity-connect/crypto': 0.2.11(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))
+      '@identity-connect/wallet-api': 0.1.4(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(aptos@1.22.1(got@11.8.6))
       axios: 1.13.2
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -4570,10 +4683,30 @@ snapshots:
       - aptos
       - debug
 
-  '@identity-connect/wallet-api@0.1.4(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(aptos@1.22.1(got@11.8.6))':
+  '@identity-connect/dapp-sdk@0.16.1(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.39.0(axios@1.13.2)(got@11.8.6)
+      '@aptos-connect/wallet-api': 0.6.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)
+      '@aptos-connect/web-transport': 0.6.1(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)
+      '@aptos-labs/ts-sdk': 5.2.1(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)
+      '@identity-connect/api': 0.8.0
+      '@identity-connect/crypto': 0.3.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@wallet-standard/core@1.0.3)
+      '@identity-connect/wallet-api': 0.2.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))
+      axios: 1.13.2
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@telegram-apps/bridge'
+      - '@wallet-standard/core'
+      - debug
+
+  '@identity-connect/wallet-api@0.1.4(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(aptos@1.22.1(got@11.8.6))':
+    dependencies:
+      '@aptos-labs/ts-sdk': 5.2.1(got@11.8.6)
       aptos: 1.22.1(got@11.8.6)
+
+  '@identity-connect/wallet-api@0.2.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))':
+    dependencies:
+      '@aptos-labs/ts-sdk': 5.2.1(got@11.8.6)
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -4621,11 +4754,11 @@ snapshots:
 
   '@microsoft/fetch-event-source@2.0.1': {}
 
-  '@mizuwallet-sdk/aptos-wallet-adapter@0.3.2(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.3.5(graphql@16.12.0)))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.0.3)(axios@1.13.2)(got@11.8.6)':
+  '@mizuwallet-sdk/aptos-wallet-adapter@0.3.2(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.3.5(graphql@16.12.0)))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.0.3)(axios@1.13.2)(got@11.8.6)':
     dependencies:
       '@aptos-labs/ts-sdk': 1.39.0(axios@1.13.2)(got@11.8.6)
       '@aptos-labs/wallet-standard': 0.1.0-ms.1(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@wallet-standard/core@1.0.3)
-      '@mizuwallet-sdk/core': 1.4.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.3.5(graphql@16.12.0))
+      '@mizuwallet-sdk/core': 1.4.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.3.5(graphql@16.12.0))
       '@mizuwallet-sdk/protocol': 0.0.6
       buffer: 6.0.3
     transitivePeerDependencies:
@@ -4633,9 +4766,9 @@ snapshots:
       - axios
       - got
 
-  '@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.3.5(graphql@16.12.0))':
+  '@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.3.5(graphql@16.12.0))':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.39.0(axios@1.13.2)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 5.2.1(got@11.8.6)
       '@mizuwallet-sdk/protocol': 0.0.6
       buffer: 6.0.3
       graphql-request: 7.3.5(graphql@16.12.0)
@@ -4647,11 +4780,11 @@ snapshots:
       tweetnacl: 1.0.3
       tweetnacl-util: 0.15.1
 
-  ? '@moveindustries/movement-design-system@https://codeload.github.com/MoveIndustries/movement-design-system/tar.gz/181b2a0eb9ddeb7e03b75450f4eb6eeaa32827de(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@aptos-labs/wallet-adapter-core@7.8.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6)))(@aptos-labs/wallet-adapter-react@7.2.2(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@types/react@18.3.27)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))(react@18.3.1))(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.3.5(graphql@16.12.0)))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))(axios@1.13.2)(got@11.8.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@4.1.17)(vite@7.2.4(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.2)(yaml@2.5.1))'
-  : dependencies:
+  '@moveindustries/movement-design-system@https://codeload.github.com/MoveIndustries/movement-design-system/tar.gz/181b2a0eb9ddeb7e03b75450f4eb6eeaa32827de(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@aptos-labs/wallet-adapter-core@8.4.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3))(@aptos-labs/wallet-adapter-react@8.3.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@types/react@18.3.27)(@wallet-standard/core@1.0.3)(react@18.3.1))(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.3.5(graphql@16.12.0)))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))(axios@1.13.2)(got@11.8.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@4.1.17)(vite@7.2.4(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.2)(yaml@2.5.1))':
+    dependencies:
       '@hookform/resolvers': 5.2.2(react-hook-form@7.67.0(react@18.3.1))
-      '@msafe/aptos-wallet-adapter': 1.1.8(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.3.5(graphql@16.12.0)))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(axios@1.13.2)(got@11.8.6)
-      '@okwallet/aptos-wallet-adapter': 0.0.7(@aptos-labs/wallet-adapter-core@7.8.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6)))(aptos@1.22.1(got@11.8.6))
+      '@msafe/aptos-wallet-adapter': 1.1.8(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.3.5(graphql@16.12.0)))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(axios@1.13.2)(got@11.8.6)
+      '@okwallet/aptos-wallet-adapter': 0.0.7(@aptos-labs/wallet-adapter-core@8.4.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3))(aptos@1.22.1(got@11.8.6))
       '@phosphor-icons/react': 2.1.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-alert-dialog': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -4700,7 +4833,7 @@ snapshots:
       vaul: 1.1.2(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       zod: 4.1.13
     optionalDependencies:
-      '@aptos-labs/wallet-adapter-react': 7.2.2(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@types/react@18.3.27)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))(react@18.3.1)
+      '@aptos-labs/wallet-adapter-react': 8.3.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@types/react@18.3.27)(@wallet-standard/core@1.0.3)(react@18.3.1)
     transitivePeerDependencies:
       - '@aptos-labs/ts-sdk'
       - '@aptos-labs/wallet-adapter-core'
@@ -4716,9 +4849,9 @@ snapshots:
       - got
       - vite
 
-  '@msafe/aptos-wallet-adapter@1.1.8(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.3.5(graphql@16.12.0)))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(axios@1.13.2)(got@11.8.6)':
+  '@msafe/aptos-wallet-adapter@1.1.8(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.3.5(graphql@16.12.0)))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(axios@1.13.2)(got@11.8.6)':
     dependencies:
-      '@aptos-labs/wallet-adapter-core': 4.25.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.3.5(graphql@16.12.0)))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))(axios@1.13.2)(got@11.8.6)
+      '@aptos-labs/wallet-adapter-core': 4.25.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.3.5(graphql@16.12.0)))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))(axios@1.13.2)(got@11.8.6)
       '@msafe/aptos-wallet': 8.0.2
       aptos: 1.22.1(got@11.8.6)
     transitivePeerDependencies:
@@ -4798,9 +4931,9 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@okwallet/aptos-wallet-adapter@0.0.7(@aptos-labs/wallet-adapter-core@7.8.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6)))(aptos@1.22.1(got@11.8.6))':
+  '@okwallet/aptos-wallet-adapter@0.0.7(@aptos-labs/wallet-adapter-core@8.4.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3))(aptos@1.22.1(got@11.8.6))':
     dependencies:
-      '@aptos-labs/wallet-adapter-core': 7.8.0(@aptos-labs/ts-sdk@1.39.0(axios@1.13.2)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)(aptos@1.22.1(got@11.8.6))
+      '@aptos-labs/wallet-adapter-core': 8.4.0(@aptos-labs/ts-sdk@5.2.1(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.0.3)
       aptos: 1.22.1(got@11.8.6)
 
   '@parcel/watcher-android-arm64@2.5.1':

--- a/src/app/api/check-eligibility/route.ts
+++ b/src/app/api/check-eligibility/route.ts
@@ -89,7 +89,10 @@ async function signEligibility(
   expirySer.serializeU64(expiry);
   const expiryBytes = expirySer.toUint8Array();
 
-  const message = new Uint8Array([...addrBytes, ...candidateBytes, ...expiryBytes]);
+  const message = new Uint8Array(addrBytes.length + candidateBytes.length + expiryBytes.length);
+  message.set(addrBytes, 0);
+  message.set(candidateBytes, addrBytes.length);
+  message.set(expiryBytes, addrBytes.length + candidateBytes.length);
 
   const signature = privateKey.sign(message);
   return signature.toString();

--- a/src/app/api/check-eligibility/route.ts
+++ b/src/app/api/check-eligibility/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Ed25519PrivateKey, AccountAddress, Serializer } from "@aptos-labs/ts-sdk";
+
+const PARTHENON_API_URL = "https://parthenon-api.movementlabs.xyz/api/users/xp-by-address";
+const XP_THRESHOLD = 100;
+const ELIGIBILITY_TTL_SECONDS = 300; // 5 min
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const address = searchParams.get("address");
+  const candidateId = searchParams.get("candidate_id");
+
+  if (!address || candidateId === null) {
+    return NextResponse.json(
+      { error: "address and candidate_id required" },
+      { status: 400 }
+    );
+  }
+
+  const candidateIdNum = parseInt(candidateId, 10);
+  if (isNaN(candidateIdNum) || candidateIdNum < 0 || candidateIdNum > 4) {
+    return NextResponse.json(
+      { error: "candidate_id must be 0-4" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const xp = await fetchXP(address);
+
+    if (xp < XP_THRESHOLD) {
+      return NextResponse.json({ eligible: false, xp });
+    }
+
+    const expiry = Math.floor(Date.now() / 1000) + ELIGIBILITY_TTL_SECONDS;
+    const signature = await signEligibility(address, candidateIdNum, expiry);
+
+    return NextResponse.json({
+      eligible: true,
+      xp,
+      signature,
+      expiry,
+    });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to check eligibility" },
+      { status: 500 }
+    );
+  }
+}
+
+async function fetchXP(address: string): Promise<number> {
+  const apiKey = process.env.PARTHENON_API_KEY;
+  if (!apiKey) throw new Error("PARTHENON_API_KEY not configured");
+
+  const url = `${PARTHENON_API_URL}?address=${encodeURIComponent(address)}`;
+  const res = await fetch(url, {
+    method: "GET",
+    headers: {
+      "X-API-KEY": apiKey,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Parthenon API returned ${res.status}`);
+  }
+
+  const data = await res.json();
+  return data?.data?.xp ?? 0;
+}
+
+async function signEligibility(
+  address: string,
+  candidateId: number,
+  expiry: number
+): Promise<string> {
+  const privateKeyHex = process.env.ELIGIBILITY_SIGNER_KEY;
+  if (!privateKeyHex) throw new Error("ELIGIBILITY_SIGNER_KEY not configured");
+
+  const privateKey = new Ed25519PrivateKey(privateKeyHex);
+
+  const addrBytes = AccountAddress.from(address).bcsToBytes();
+
+  const candidateSer = new Serializer();
+  candidateSer.serializeU64(candidateId);
+  const candidateBytes = candidateSer.toUint8Array();
+
+  const expirySer = new Serializer();
+  expirySer.serializeU64(expiry);
+  const expiryBytes = expirySer.toUint8Array();
+
+  const message = new Uint8Array([...addrBytes, ...candidateBytes, ...expiryBytes]);
+
+  const signature = privateKey.sign(message);
+  return signature.toString();
+}

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -22,6 +22,22 @@ export default function EventsPage() {
           Events & Resources
         </Typography>
 
+        {/* People's Choice Voting */}
+        <div className="mb-8 p-6 rounded-xl border border-guild-green-400 bg-black/50">
+          <Typography variant="h3" className="text-guild-green-400 mb-3">
+            People&apos;s Choice Award
+          </Typography>
+          <Text className="text-muted-foreground mb-4">
+            Vote for your favorite M1 Hackathon project on-chain. Connect your
+            Movement wallet and cast your vote!
+          </Text>
+          <Button variant="default" size="lg" asChild>
+            <Link href="/events/peopleschoice">
+              Vote Now
+            </Link>
+          </Button>
+        </div>
+
         {/* Open Claw Hackathon */}
         <div className="mb-8 p-6 rounded-xl border border-guild-green-400 bg-black/50">
           <Typography variant="h3" className="text-guild-green-400 mb-3">

--- a/src/app/events/peopleschoice/layout.tsx
+++ b/src/app/events/peopleschoice/layout.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { AptosWalletAdapterProvider } from "@aptos-labs/wallet-adapter-react";
+import { AptosConfig, Network } from "@aptos-labs/ts-sdk";
+
+const aptosConfig = new AptosConfig({
+  network: Network.MAINNET,
+  fullnode: "https://mainnet.movementnetwork.xyz/v1",
+});
+
+export default function PeoplesChoiceLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <AptosWalletAdapterProvider
+      autoConnect={true}
+      dappConfig={aptosConfig}
+      onError={(error) => {
+        console.error("Wallet error:", JSON.stringify(error, null, 2));
+      }}
+    >
+      {children}
+    </AptosWalletAdapterProvider>
+  );
+}

--- a/src/app/events/peopleschoice/page.tsx
+++ b/src/app/events/peopleschoice/page.tsx
@@ -329,13 +329,13 @@ export default function PeoplesChoicePage() {
             return (
               <Card
                 key={nominee.id}
-                className={`transition-colors ${
+                className={`flex flex-col transition-colors ${
                   isVotedFor
                     ? "border-guild-green-400 ring-2 ring-guild-green-400/50"
                     : "border-guild-green-400-20 hover:border-guild-green-400"
                 }`}
               >
-                <CardHeader>
+                <CardHeader className="flex-1">
                   <div className="flex items-center justify-between mb-2">
                     <Badge variant="secondary">{nominee.prize}</Badge>
                     <Badge variant="secondary">
@@ -347,7 +347,7 @@ export default function PeoplesChoicePage() {
                     {nominee.description}
                   </CardDescription>
                 </CardHeader>
-                <CardFooter className="gap-2 flex-wrap">
+                <CardFooter className="gap-2 flex-wrap mt-auto">
                   {nominee.videoUrl && (
                     <Button variant="outline" size="sm" asChild>
                       <Link

--- a/src/app/events/peopleschoice/page.tsx
+++ b/src/app/events/peopleschoice/page.tsx
@@ -1,0 +1,420 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { useWallet } from "@aptos-labs/wallet-adapter-react";
+import { Aptos, AptosConfig, Network } from "@aptos-labs/ts-sdk";
+import {
+  Typography,
+  Text,
+  Button,
+  DottedBackground,
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardFooter,
+  Badge,
+} from "@movementlabsxyz/movement-design-system";
+import {
+  peoplesChoiceNominees,
+  PeoplesChoiceNominee,
+} from "@/data/peoples-choice-nominees";
+import {
+  PEOPLES_CHOICE_MODULE,
+  MOVEMENT_MAINNET_URL,
+} from "@/lib/contracts";
+import { WalletSelectionModal } from "@/components/WalletSelectionModal";
+
+type VotingState =
+  | "disconnected"
+  | "checking"
+  | "eligible"
+  | "ineligible"
+  | "already_voted"
+  | "voting"
+  | "voted"
+  | "error";
+
+const aptosConfig = new AptosConfig({
+  network: Network.CUSTOM,
+  fullnode: MOVEMENT_MAINNET_URL,
+});
+const aptos = new Aptos(aptosConfig);
+
+const POLL_INTERVAL = 15_000;
+
+export default function PeoplesChoicePage() {
+  const { account, connected, disconnect, signAndSubmitTransaction } = useWallet();
+
+  const [votingState, setVotingState] = useState<VotingState>("disconnected");
+  const [voteCounts, setVoteCounts] = useState<number[]>(new Array(5).fill(0));
+  const [votedFor, setVotedFor] = useState<number | null>(null);
+  const [xp, setXp] = useState<number>(0);
+  const [errorMsg, setErrorMsg] = useState<string>("");
+  const [selectedCandidate, setSelectedCandidate] = useState<number | null>(null);
+
+  const fetchVoteCounts = useCallback(async () => {
+    try {
+      const result = await aptos.view({
+        payload: {
+          function: `${PEOPLES_CHOICE_MODULE.address}::${PEOPLES_CHOICE_MODULE.moduleName}::${PEOPLES_CHOICE_MODULE.views.getVotes}`,
+          typeArguments: [],
+          functionArguments: [],
+        },
+      });
+      if (result && Array.isArray(result[0])) {
+        setVoteCounts(result[0].map(Number));
+      }
+    } catch {
+      // Contract may not be deployed yet
+    }
+  }, []);
+
+  const checkAlreadyVoted = useCallback(async (addr: string) => {
+    try {
+      const result = await aptos.view({
+        payload: {
+          function: `${PEOPLES_CHOICE_MODULE.address}::${PEOPLES_CHOICE_MODULE.moduleName}::${PEOPLES_CHOICE_MODULE.views.hasVoted}`,
+          typeArguments: [],
+          functionArguments: [addr],
+        },
+      });
+      if (result && result[0] === true) {
+        const choiceResult = await aptos.view({
+          payload: {
+            function: `${PEOPLES_CHOICE_MODULE.address}::${PEOPLES_CHOICE_MODULE.moduleName}::${PEOPLES_CHOICE_MODULE.views.getVoterChoice}`,
+            typeArguments: [],
+            functionArguments: [addr],
+          },
+        });
+        setVotedFor(Number(choiceResult[0]));
+        return true;
+      }
+      return false;
+    } catch {
+      return false;
+    }
+  }, []);
+
+  const checkEligibility = useCallback(async (addr: string) => {
+    setVotingState("checking");
+    try {
+      const alreadyVoted = await checkAlreadyVoted(addr);
+      if (alreadyVoted) {
+        setVotingState("already_voted");
+        return;
+      }
+
+      const res = await fetch(`/api/check-eligibility?address=${addr}&candidate_id=0`);
+      const data = await res.json();
+      setXp(data.xp ?? 0);
+
+      if (data.eligible) {
+        setVotingState("eligible");
+      } else {
+        setVotingState("ineligible");
+      }
+    } catch {
+      setVotingState("error");
+      setErrorMsg("Failed to check eligibility. Please try again.");
+    }
+  }, [checkAlreadyVoted]);
+
+  useEffect(() => {
+    if (connected && account?.address) {
+      checkEligibility(account.address.toString());
+    } else {
+      setVotingState("disconnected");
+      setVotedFor(null);
+      setXp(0);
+    }
+  }, [connected, account?.address, checkEligibility]);
+
+  useEffect(() => {
+    fetchVoteCounts();
+    const interval = setInterval(fetchVoteCounts, POLL_INTERVAL);
+    return () => clearInterval(interval);
+  }, [fetchVoteCounts]);
+
+  const handleVote = async (candidateId: number) => {
+    if (!account?.address) return;
+    setSelectedCandidate(candidateId);
+    setVotingState("voting");
+    setErrorMsg("");
+
+    try {
+      const res = await fetch(
+        `/api/check-eligibility?address=${account.address.toString()}&candidate_id=${candidateId}`
+      );
+      const data = await res.json();
+
+      if (!data.eligible || !data.signature || !data.expiry) {
+        setVotingState("error");
+        setErrorMsg("Eligibility verification failed.");
+        return;
+      }
+
+      const sigHex = (data.signature as string).replace(/^0x/, "");
+      const sigBytes = new Uint8Array(
+        sigHex.match(/.{1,2}/g)!.map((byte: string) => parseInt(byte, 16))
+      );
+
+      const response = await signAndSubmitTransaction({
+        sender: account.address,
+        data: {
+          function: `${PEOPLES_CHOICE_MODULE.address}::${PEOPLES_CHOICE_MODULE.moduleName}::${PEOPLES_CHOICE_MODULE.functions.vote}`,
+          functionArguments: [
+            candidateId,
+            sigBytes,
+            data.expiry,
+          ],
+        },
+      });
+
+      try {
+        const txResult = await aptos.waitForTransaction({
+          transactionHash: response.hash,
+          options: { checkSuccess: true },
+        });
+
+        if (!txResult.success) {
+          setVotingState("error");
+          setErrorMsg("Transaction failed on-chain. Please try again.");
+          return;
+        }
+      } catch {
+        setVotingState("error");
+        setErrorMsg("Transaction failed or timed out. Please try again.");
+        return;
+      }
+
+      setVotedFor(candidateId);
+      setVotingState("voted");
+      fetchVoteCounts();
+    } catch (err: unknown) {
+      setVotingState("error");
+      if (err instanceof Error) {
+        if (err.message.includes("rejected") || err.message.includes("Rejected")) {
+          setErrorMsg("Transaction was rejected. Please try again.");
+        } else if (err.message.includes("ALREADY_VOTED")) {
+          setErrorMsg("You have already voted.");
+          setVotingState("already_voted");
+        } else {
+          setErrorMsg(err.message);
+        }
+      } else {
+        setErrorMsg("Something went wrong. Please try again.");
+      }
+    }
+  };
+
+  const totalVotes = voteCounts.reduce((a, b) => a + b, 0);
+
+  return (
+    <DottedBackground
+      variant="dots"
+      dotColor="var(--color-neutrals-white-alpha-300)"
+      className="min-h-screen py-32"
+    >
+      <div className="max-w-6xl mx-auto px-4">
+        {/* Hero */}
+        <div className="text-center mb-12">
+          <Typography variant="h1" className="text-guild-green-400 mb-4">
+            People&apos;s Choice Award
+          </Typography>
+          <Text className="text-muted-foreground text-lg max-w-2xl mx-auto">
+            Vote for your favorite M1 Hackathon project. Connect your Movement
+            wallet and cast your vote on-chain. Requires 100+ XP on Parthenon.
+          </Text>
+          {totalVotes > 0 && (
+            <Text className="text-muted-foreground mt-2">
+              {totalVotes} total vote{totalVotes !== 1 ? "s" : ""} cast
+            </Text>
+          )}
+        </div>
+
+        {/* Wallet / Status Section */}
+        <div className="text-center mb-10">
+          {votingState === "disconnected" && (
+            <div className="flex flex-col items-center gap-3">
+              <Text className="text-muted-foreground mb-2">
+                Connect your wallet to vote
+              </Text>
+              <WalletSelectionModal>
+                <Button variant="default" size="lg">
+                  Connect Wallet
+                </Button>
+              </WalletSelectionModal>
+            </div>
+          )}
+
+          {votingState === "checking" && (
+            <Text className="text-guild-green-400">
+              Checking eligibility...
+            </Text>
+          )}
+
+          {votingState === "ineligible" && (
+            <div className="p-4 rounded-xl border border-red-500/50 bg-red-500/10 inline-block">
+              <Text className="text-red-400">
+                You need at least 100 XP to vote. Your current XP: {xp}
+              </Text>
+            </div>
+          )}
+
+          {votingState === "eligible" && (
+            <div className="p-4 rounded-xl border border-guild-green-400/50 bg-guild-green-400/10 inline-block">
+              <Text className="text-guild-green-400">
+                You&apos;re eligible to vote! Select a project below. (XP: {xp})
+              </Text>
+            </div>
+          )}
+
+          {(votingState === "already_voted" || votingState === "voted") && (
+            <div className="p-4 rounded-xl border border-guild-green-400/50 bg-guild-green-400/10 inline-block">
+              <Text className="text-guild-green-400">
+                You voted for{" "}
+                <span className="font-bold">
+                  {votedFor !== null
+                    ? peoplesChoiceNominees[votedFor]?.name
+                    : "a project"}
+                </span>
+                !
+              </Text>
+            </div>
+          )}
+
+          {votingState === "voting" && (
+            <Text className="text-guild-green-400">
+              Submitting your vote...
+            </Text>
+          )}
+
+          {votingState === "error" && (
+            <div className="p-4 rounded-xl border border-red-500/50 bg-red-500/10 inline-flex flex-col items-center gap-3">
+              <Text className="text-red-400">
+                {errorMsg || "An error occurred"}
+              </Text>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setErrorMsg("");
+                  if (account?.address) {
+                    checkEligibility(account.address.toString());
+                  }
+                }}
+              >
+                Try Again
+              </Button>
+            </div>
+          )}
+
+          {connected && votingState !== "disconnected" && (
+            <div className="mt-3">
+              <Button variant="outline" size="sm" onClick={disconnect}>
+                Disconnect
+              </Button>
+            </div>
+          )}
+        </div>
+
+        {/* Nominees Grid */}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {peoplesChoiceNominees.map((nominee: PeoplesChoiceNominee) => {
+            const isVotedFor = votedFor === nominee.id;
+            const count = voteCounts[nominee.id] ?? 0;
+
+            return (
+              <Card
+                key={nominee.id}
+                className={`transition-colors ${
+                  isVotedFor
+                    ? "border-guild-green-400 ring-2 ring-guild-green-400/50"
+                    : "border-guild-green-400-20 hover:border-guild-green-400"
+                }`}
+              >
+                <CardHeader>
+                  <div className="flex items-center justify-between mb-2">
+                    <Badge variant="secondary">{nominee.prize}</Badge>
+                    <Badge variant="secondary">
+                      {count} vote{count !== 1 ? "s" : ""}
+                    </Badge>
+                  </div>
+                  <CardTitle className="text-white">{nominee.name}</CardTitle>
+                  <CardDescription className="text-muted-foreground">
+                    {nominee.description}
+                  </CardDescription>
+                </CardHeader>
+                <CardFooter className="gap-2 flex-wrap">
+                  {nominee.videoUrl && (
+                    <Button variant="outline" size="sm" asChild>
+                      <Link
+                        href={nominee.videoUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Video
+                      </Link>
+                    </Button>
+                  )}
+                  {nominee.demoUrl && (
+                    <Button variant="outline" size="sm" asChild>
+                      <Link
+                        href={nominee.demoUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Demo
+                      </Link>
+                    </Button>
+                  )}
+                  {nominee.repoUrl && (
+                    <Button variant="outline" size="sm" asChild>
+                      <Link
+                        href={nominee.repoUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Repo
+                      </Link>
+                    </Button>
+                  )}
+                  {votingState === "eligible" && (
+                    <Button
+                      variant="default"
+                      size="sm"
+                      onClick={() => handleVote(nominee.id)}
+                      disabled={votingState !== "eligible"}
+                    >
+                      Vote
+                    </Button>
+                  )}
+                  {votingState === "voting" &&
+                    selectedCandidate === nominee.id && (
+                      <Button variant="default" size="sm" disabled>
+                        Voting...
+                      </Button>
+                    )}
+                  {isVotedFor && (
+                    <Badge variant="secondary" className="bg-guild-green-400/20 text-guild-green-400">
+                      Your Vote
+                    </Badge>
+                  )}
+                </CardFooter>
+              </Card>
+            );
+          })}
+        </div>
+
+        {/* Back Button */}
+        <div className="mt-12 text-center">
+          <Button variant="outline" size="lg" asChild>
+            <Link href="/events">Back to Events</Link>
+          </Button>
+        </div>
+      </div>
+    </DottedBackground>
+  );
+}

--- a/src/components/WalletSelectionModal.tsx
+++ b/src/components/WalletSelectionModal.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import { useWallet } from "@aptos-labs/wallet-adapter-react";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@movementlabsxyz/movement-design-system";
+
+interface WalletSelectionModalProps {
+  children: React.ReactNode;
+}
+
+export function WalletSelectionModal({ children }: WalletSelectionModalProps) {
+  const [open, setOpen] = useState(false);
+  const { wallets, connect } = useWallet();
+
+  const filteredWallets = wallets
+    .filter((wallet) => {
+      const name = wallet.name.toLowerCase();
+      return (
+        !name.includes("petra") &&
+        !name.includes("google") &&
+        !name.includes("apple")
+      );
+    })
+    .filter((wallet, index, self) => {
+      return index === self.findIndex((w) => w.name === wallet.name);
+    })
+    .sort((a, b) => {
+      if (a.name.toLowerCase().includes("nightly")) return -1;
+      if (b.name.toLowerCase().includes("nightly")) return 1;
+      return 0;
+    });
+
+  const handleWalletSelect = async (walletName: string) => {
+    try {
+      await connect(walletName);
+      setOpen(false);
+    } catch {
+      // wallet adapter handles error display
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Connect Wallet</DialogTitle>
+          <DialogDescription>
+            Choose a wallet to connect to Movement Network. Make sure your
+            wallet is set to Movement Mainnet before connecting.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          {filteredWallets.length === 0 ? (
+            <p className="text-center text-muted-foreground py-4">
+              No compatible wallets detected. Please install a supported wallet.
+            </p>
+          ) : (
+            filteredWallets.map((wallet) => (
+              <Button
+                key={wallet.name}
+                variant="outline"
+                className="w-full justify-start h-12"
+                onClick={() => handleWalletSelect(wallet.name)}
+              >
+                <div className="flex items-center space-x-3">
+                  {wallet.icon && (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={wallet.icon}
+                      alt={wallet.name}
+                      className="w-6 h-6"
+                    />
+                  )}
+                  <span>{wallet.name}</span>
+                </div>
+              </Button>
+            ))
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/data/peoples-choice-nominees.ts
+++ b/src/data/peoples-choice-nominees.ts
@@ -1,0 +1,56 @@
+export interface PeoplesChoiceNominee {
+  id: number;
+  name: string;
+  description: string;
+  prize: string;
+  repoUrl?: string;
+  videoUrl?: string;
+  demoUrl?: string;
+  slidesUrl?: string;
+}
+
+export const peoplesChoiceNominees: PeoplesChoiceNominee[] = [
+  {
+    id: 0,
+    name: "The Fallen Court",
+    prize: "People's Choice Nominee",
+    description:
+      "Narrative-driven ASCII dungeon crawler with blockchain integration for real stakes and on-chain NFTs.",
+    videoUrl: "https://youtu.be/GAcvInDh69Y",
+    demoUrl: "https://www.thefallencourt.com/",
+  },
+  {
+    id: 1,
+    name: "AlgoArena",
+    prize: "People's Choice Nominee",
+    description:
+      "Competitive auto-battler game with AI trading agents on live crypto using x402 micropayments.",
+    videoUrl: "https://www.youtube.com/watch?v=CaYiyJwoorY",
+    demoUrl: "https://movealgoarena.vercel.app/",
+  },
+  {
+    id: 2,
+    name: "Movers Map",
+    prize: "People's Choice Nominee",
+    description:
+      "Community-driven mapping platform built on Movement for decentralized location data.",
+    videoUrl: "https://x.com/Soke_Decentra/status/2009928574921240808?s=20",
+    demoUrl: "https://moversmap.netlify.app/",
+  },
+  {
+    id: 3,
+    name: "Ashfall",
+    prize: "People's Choice Nominee",
+    description:
+      "Post-apocalyptic on-chain survival game with player-owned economies on Movement.",
+  },
+  {
+    id: 4,
+    name: "The Village",
+    prize: "People's Choice Nominee",
+    description:
+      "Social coordination platform enabling community governance and collective decision-making on-chain.",
+    videoUrl: "https://www.youtube.com/watch?v=60qJEG2PMDE",
+    demoUrl: "https://github.com/jomarip/thevillage",
+  },
+];

--- a/src/data/peoples-choice-nominees.ts
+++ b/src/data/peoples-choice-nominees.ts
@@ -39,18 +39,11 @@ export const peoplesChoiceNominees: PeoplesChoiceNominee[] = [
   },
   {
     id: 3,
-    name: "Ashfall",
-    prize: "People's Choice Nominee",
-    description:
-      "Post-apocalyptic on-chain survival game with player-owned economies on Movement.",
-  },
-  {
-    id: 4,
     name: "The Village",
     prize: "People's Choice Nominee",
     description:
       "Social coordination platform enabling community governance and collective decision-making on-chain.",
     videoUrl: "https://www.youtube.com/watch?v=60qJEG2PMDE",
-    demoUrl: "https://github.com/jomarip/thevillage",
+    demoUrl: "https://thevillage-khaki.vercel.app/",
   },
 ];

--- a/src/lib/contracts.ts
+++ b/src/lib/contracts.ts
@@ -1,0 +1,24 @@
+export const MOVEMENT_MAINNET_URL = "https://mainnet.movementnetwork.xyz/v1";
+export const MOVEMENT_TESTNET_URL = "https://testnet.movementnetwork.xyz/v1";
+
+export const PEOPLES_CHOICE_MODULE = {
+  address: process.env.NEXT_PUBLIC_CONTRACT_ADDRESS || "0x1",
+  moduleName: "peoples_choice",
+  functions: {
+    vote: "vote",
+    pause: "pause",
+    unpause: "unpause",
+    initialize: "initialize",
+  },
+  views: {
+    getVotes: "get_votes",
+    hasVoted: "has_voted",
+    getVoterChoice: "get_voter_choice",
+  },
+} as const;
+
+export const MOVEMENT_NETWORK = {
+  name: "Movement Mainnet" as const,
+  chainId: 126,
+  url: MOVEMENT_MAINNET_URL,
+};


### PR DESCRIPTION
## Summary
- Add `/events/peopleschoice` with on-chain voting for M1 Hackathon People's Choice Award
- Wallet connect modal (AIP-62 compatible, Petra filtered out) with eligibility check via Parthenon API (>=100 XP)
- Ed25519 signature verification: server signs eligibility proof, contract verifies on-chain
- Move smart contract source included at `contracts/peoples_choice/` (deployed to mainnet)
- Tutorial and events hub updated with link

## Env vars needed
```
PARTHENON_API_KEY=<key>
ELIGIBILITY_SIGNER_KEY=<ed25519-private-key>
NEXT_PUBLIC_CONTRACT_ADDRESS=0x9e125ef34b46202e928ce15d2d0681cfb974394e2085569fd8839240a4c6dc0e
```

## Test plan
- [ ] Set env vars in Vercel
- [ ] Verify `/events/peopleschoice` renders with all 5 nominees
- [ ] Connect wallet, confirm eligibility check passes for wallets with >=100 XP
- [ ] Cast a vote, confirm tx succeeds on-chain and vote count updates
- [ ] Disconnect and reconnect, confirm "already voted" state persists
- [ ] Verify `/events` page shows People's Choice card

🤖 Generated with [Claude Code](https://claude.com/claude-code)